### PR TITLE
Issue 168 - Fix parsing references with trailing periods after book n…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Issue #168](https://github.com/avendesora/pythonbible/issues/168) - Parse references when book names are followed by periods.
+
 ## [0.15.5] - 2026-01-24
 
 ### Fixed

--- a/pythonbible/pythonbible/parser.py
+++ b/pythonbible/pythonbible/parser.py
@@ -158,12 +158,19 @@ def _process_sub_references(
     start_chapter: int | None = None
 
     for sub_reference in reference.split(COMMA):
-        if (not sub_reference or sub_reference in {DASH, PERIOD}) and not references:
+        normalized_sub_reference = sub_reference.strip().lstrip(" .,:;-")
+
+        if (
+            not normalized_sub_reference
+            or normalized_sub_reference in {DASH, PERIOD}
+        ) and not references:
             references.append(NormalizedReference(book, None, None, None, None, book))
             continue
 
         start_chapter, start_verse, end_chapter, end_verse = _process_sub_reference(
-            sub_reference[:-1] if sub_reference.endswith(DASH) else sub_reference,
+            normalized_sub_reference[:-1]
+            if normalized_sub_reference.endswith(DASH)
+            else normalized_sub_reference,
             book,
             start_chapter,
         )
@@ -195,7 +202,8 @@ def _process_sub_reference(
     end_verse: int | None = None
     no_verses: bool = False
 
-    clean_sub_reference: str = sub_reference.replace(PERIOD, COLON)
+    clean_sub_reference: str = sub_reference.strip().lstrip(" .,:;-")
+    clean_sub_reference = clean_sub_reference.replace(PERIOD, COLON)
     chapter_and_verse_range: list[str] = clean_sub_reference.split(DASH)
     min_chapter_and_verse: list[str] = chapter_and_verse_range[0].strip().split(COLON)
 

--- a/pythonbible/pythonbible/parser.py
+++ b/pythonbible/pythonbible/parser.py
@@ -161,8 +161,7 @@ def _process_sub_references(
         normalized_sub_reference = sub_reference.strip().lstrip(" .,:;-")
 
         if (
-            not normalized_sub_reference
-            or normalized_sub_reference in {DASH}
+            not normalized_sub_reference or normalized_sub_reference in {DASH}
         ) and not references:
             references.append(NormalizedReference(book, None, None, None, None, book))
             continue

--- a/pythonbible/pythonbible/parser.py
+++ b/pythonbible/pythonbible/parser.py
@@ -161,7 +161,8 @@ def _process_sub_references(
         normalized_sub_reference = sub_reference.strip().lstrip(" .,:;-")
 
         if (
-            not normalized_sub_reference or normalized_sub_reference in {DASH, PERIOD}
+            not normalized_sub_reference
+            or normalized_sub_reference in {DASH}
         ) and not references:
             references.append(NormalizedReference(book, None, None, None, None, book))
             continue

--- a/pythonbible/pythonbible/parser.py
+++ b/pythonbible/pythonbible/parser.py
@@ -161,8 +161,7 @@ def _process_sub_references(
         normalized_sub_reference = sub_reference.strip().lstrip(" .,:;-")
 
         if (
-            not normalized_sub_reference
-            or normalized_sub_reference in {DASH, PERIOD}
+            not normalized_sub_reference or normalized_sub_reference in {DASH, PERIOD}
         ) and not references:
             references.append(NormalizedReference(book, None, None, None, None, book))
             continue

--- a/pythonbible/tests/parser/parser_test.py
+++ b/pythonbible/tests/parser/parser_test.py
@@ -116,6 +116,75 @@ def test_normalize_reference_range_without_verse_numbers(
     )
 
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            "Micah. 2",
+            [
+                bible.NormalizedReference(
+                    bible.Book.MICAH,
+                    2,
+                    None,
+                    2,
+                    None,
+                    bible.Book.MICAH,
+                )
+            ],
+        ),
+        (
+            "Psalm. 46",
+            [
+                bible.NormalizedReference(
+                    bible.Book.PSALMS,
+                    46,
+                    None,
+                    46,
+                    None,
+                    bible.Book.PSALMS,
+                )
+            ],
+        ),
+        (
+            "Psalms. 74",
+            [
+                bible.NormalizedReference(
+                    bible.Book.PSALMS,
+                    74,
+                    None,
+                    74,
+                    None,
+                    bible.Book.PSALMS,
+                )
+            ],
+        ),
+        (
+            "1Peter. 1:22",
+            [
+                bible.NormalizedReference(
+                    bible.Book.PETER_1,
+                    1,
+                    22,
+                    1,
+                    22,
+                    bible.Book.PETER_1,
+                )
+            ],
+        ),
+    ],
+)
+def test_get_references_book_name_followed_by_period(
+    text: str,
+    expected: list[bible.NormalizedReference],
+) -> None:
+    # Given a reference where a book name is immediately followed by a period
+    # When it is parsed
+    references: list[bible.NormalizedReference] = bible.get_references(text)
+
+    # Then the reference is returned without crashing or discarding the chapter/verse
+    assert references == expected
+
+
 def test_get_references_roman_numerals(
     roman_numeral_references: str,
     normalized_references_complex: list[bible.NormalizedReference],

--- a/pythonbible/tests/parser/parser_test.py
+++ b/pythonbible/tests/parser/parser_test.py
@@ -182,7 +182,8 @@ def test_get_references_book_name_followed_by_period(
     references: list[bible.NormalizedReference] = bible.get_references(text)
 
     # Then the reference is returned without crashing or discarding the chapter/verse
-    assert references == expected
+    if references != expected:
+        raise AssertionError(f"Expected {expected!r}, got {references!r}")
 
 
 def test_get_references_roman_numerals(


### PR DESCRIPTION
…ames (#168)

Fixes examples reported in #168 such as 'Micah. 2Ch. 34:20', 'Psalm. 46', 'Psalms. 74', and '1Peter. 1:22'. The parser now strips punctuation after the matched book name before interpreting chapter and verse values, avoiding empty-string int conversion errors.

# Description

Fixes https://github.com/avendesora/pythonbible/issues/168
I wanted to test out AI and it's ability to fix bugs. 

# Checklist:

- [X ] I have read the [CONTRIBUTING](https://github.com/avendesora/pythonbible/CONTRIBUTING.md) document.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X ] I have run pre-commit locally prior to submission and fixed any errors/warnings.
- [X ] I have run tests locally prior to submission and they are passing.
- [NA ] I have added necessary documentation (if appropriate).
- [NA] I have updated the README (if appropriate).
- [X ] I have updated the CHANGELOG (if appropriate).
- [NA] I have updated the version number (if appropriate).
- [NA] I have updated the requirements (if appropriate).

## Summary by Sourcery

Handle punctuation after Bible book names so affected references parse correctly.

Bug Fixes:
- Fix parsing of Bible references when book names are followed by periods, preserving chapter and verse values without errors.

Tests:
- Add coverage for references with trailing periods after several book-name formats.